### PR TITLE
V2 of scripting-languages branch, with a score cache

### DIFF
--- a/codingame/2025-spring-challenge/scripting-languages/spring-challenge-2025.py
+++ b/codingame/2025-spring-challenge/scripting-languages/spring-challenge-2025.py
@@ -1,0 +1,90 @@
+from typing import Dict, List, Callable, Tuple, Any
+
+StateRaw = int  # Type alias
+Score = int     # Type alias
+TransformationFunction = Callable[[StateRaw], StateRaw]
+
+class State:
+    def __init__(self, canonical_state: StateRaw, transform: TransformationFunction):
+        self.canonical_state = canonical_state
+        self.transform = transform
+
+max_depth = 1
+
+next_states_cache: Dict[StateRaw, List[State]] = {}
+
+def get_input() -> Tuple[StateRaw, int]:
+    """
+    Return the initial state and the maximum depth.
+    TODO: already implemented in C++
+    """
+    return 0, 1  # initialState, inputMaxDepth
+
+def make_canonical(sr: StateRaw) -> State:
+    """
+    Convert a raw state to its canonical form.
+    TODO: almost implemented already in C++
+    Instead of returning a function, we'd return function ID
+    """
+    return State(
+        canonical_state=0,
+        transform=lambda sr: sr
+    )
+
+def calculate_next_states_raw(sr: StateRaw) -> List[StateRaw]:
+    """
+    Calculate the next possible raw states from a given raw state.
+    TODO: implemented already in C++
+    """
+    return []
+
+def calculate_next_states(s: State) -> List[State]:
+    """Calculate the next possible states from a given state."""
+    # check cache
+    if s.canonical_state in next_states_cache:
+        return next_states_cache[s.canonical_state]
+
+    next_raw_states: List[StateRaw] = calculate_next_states_raw(s.canonical_state)
+    next_states: List[State] = [make_canonical(state) for state in next_raw_states]
+    
+    # populate next states cache and return
+    next_states_cache[s.canonical_state] = next_states
+    return next_states
+
+def calculate_score(current_state: State, depth: int) -> Score:
+    """Calculate the score for a given state and depth."""
+    canonical_state = current_state.canonical_state
+    transform = current_state.transform
+
+    # Opt: add a score cache(gs_raw, d)
+
+    if depth == max_depth:
+        current_state_raw = transform(canonical_state)
+        return current_state_raw  # as Score
+
+    next_states: List[State] = calculate_next_states(current_state)
+    next_states_scores: List[Score] = []  # same length as 'nextStates'
+
+    for next_state in next_states:
+        next_state_score = calculate_score(next_state, depth + 1)
+        next_state_score_transformed = transform(next_state_score)  # as StateRaw, then as Score
+        next_states_scores.append(next_state_score_transformed)
+    
+    return sum(next_states_scores)
+
+def main():
+    """Main function to run the algorithm."""
+    initial_state, input_max_depth = get_input()
+    
+    global max_depth
+    max_depth = input_max_depth
+    
+    initial_state_canonical = make_canonical(initial_state)
+    initial_state_score_canonical = calculate_score(initial_state_canonical, 0)  # not sure if starts with 0 or 1
+
+    initial_state_score = initial_state_canonical.transform(initial_state_score_canonical)  # as StateRaw, then as Score
+
+    print(f"Calculated score: {initial_state_score}")
+
+if __name__ == "__main__":
+    main()

--- a/codingame/2025-spring-challenge/scripting-languages/spring-challenge-2025.ts
+++ b/codingame/2025-spring-challenge/scripting-languages/spring-challenge-2025.ts
@@ -1,0 +1,83 @@
+
+type StateRaw = number;
+type Score = number;
+type TransformationFunction = (stateRaw: StateRaw) => StateRaw;
+type State = {
+  canonicalState: StateRaw, // canonical representation of the "raw" state
+  transform: TransformationFunction // function such that transform(canonicalState) = stateRaw
+}
+
+let maxDepth = 1;
+
+const nextStatesCache: Record<StateRaw, State[]> = {};
+
+function getInput(): { initialState: StateRaw, inputMaxDepth: number } {
+  // TODO: already implemnted in C++
+  return {
+    initialState: 0,
+    inputMaxDepth: 1,
+  }
+}
+
+function makeCanonical(sr: StateRaw): State {
+  // TODO: almost imlemented already in C++
+  // instead of returning a function, we'd return function ID
+  return {
+    canonicalState: 0,
+    transform: (sr: StateRaw) => sr,
+  }
+}
+
+function calculateNextStatesRaw(sr: StateRaw): StateRaw[] {
+  // TODO: implemented already in C++
+  return [];
+};
+
+function calculateNextStates(s: State): State[] {
+  // check cache
+  if (nextStatesCache[s.canonicalState] !== undefined) {
+    return nextStatesCache[s.canonicalState]
+  }
+
+  const nextRawStates: StateRaw[] = calculateNextStatesRaw(s.canonicalState);
+
+  const nextStates: State[] = nextRawStates.map(makeCanonical);
+  
+  // populate next states cache and return
+  nextStatesCache[s.canonicalState] = nextStates;
+  return nextStates;
+}
+
+function calculateScore(currentState: State, depth: number): Score {
+  const { canonicalState, transform } = currentState;
+
+  // Opt: add a score cache(gs_raw, d)
+
+  if (depth === maxDepth) {
+    const currentStateRaw = transform(canonicalState);
+    return currentStateRaw as Score;
+  }
+  
+  const nextStates: State[] = calculateNextStates(currentState);
+
+  const nextStatesScores: Score[] = []; // same length as 'nextStates'
+
+  for (const nextState of nextStates) {
+    const nextStateScore = calculateScore(nextState, depth + 1);
+    const nextStateScoreTransformed = transform(nextStateScore as StateRaw) as Score;
+    nextStatesScores.push(nextStateScoreTransformed);
+  }
+  return nextStatesScores.reduce((acc, score) => acc + score, 0);
+}
+
+function main() {
+  const { initialState, inputMaxDepth } = getInput();
+  
+  maxDepth = inputMaxDepth;
+  const initialStateCanonical = makeCanonical(initialState);
+  const initialStateScoreCanonical = calculateScore(initialStateCanonical, 0); // not sure if starts with 0 or 1
+
+  const initialStateScore = initialStateCanonical.transform(initialStateScoreCanonical as StateRaw) as Score;
+
+  console.log(`Calculated score: ${initialStateScore}`);
+}

--- a/codingame/2025-spring-challenge/scripting-languages/spring-challenge-2025.ts
+++ b/codingame/2025-spring-challenge/scripting-languages/spring-challenge-2025.ts
@@ -1,4 +1,5 @@
 
+type StateAndDepth = string;
 type StateRaw = number;
 type Score = number;
 type TransformationFunction = (stateRaw: StateRaw) => StateRaw;
@@ -10,6 +11,7 @@ type State = {
 let maxDepth = 1;
 
 const nextStatesCache: Record<StateRaw, State[]> = {};
+const scoreCache: Record<StateAndDepth, Score> = {}; // cache the scores for each (state,depth) pair (must keep depth because score is not unique, depends how deep you are)
 
 function getInput(): { initialState: StateRaw, inputMaxDepth: number } {
   // TODO: already implemnted in C++
@@ -51,7 +53,10 @@ function calculateNextStates(s: State): State[] {
 function calculateScore(currentState: State, depth: number): Score {
   const { canonicalState, transform } = currentState;
 
-  // Opt: add a score cache(gs_raw, d)
+  const stateAndDepth = `${canonicalState}-${depth}`; // can improve with a pair, if pair can be hashed
+  if (scoreCache[stateAndDepth] !== undefined) {
+    return scoreCache[stateAndDepth];
+  }
 
   if (depth === maxDepth) {
     const currentStateRaw = transform(canonicalState);
@@ -67,7 +72,11 @@ function calculateScore(currentState: State, depth: number): Score {
     const nextStateScoreTransformed = transform(nextStateScore as StateRaw) as Score;
     nextStatesScores.push(nextStateScoreTransformed);
   }
-  return nextStatesScores.reduce((acc, score) => acc + score, 0);
+
+  // populate score cache and return
+  const result = nextStatesScores.reduce((acc, score) => acc + score, 0);
+  scoreCache[stateAndDepth] = result;
+  return result;
 }
 
 function main() {


### PR DESCRIPTION
Given that we might encounter the same state several time, it might be worth using more memory to have more speed, and store the score per state.

This means, that for a state S, instead of only storing its children, we also store its score*.
- If we find the score is already calculated for that state at that depth, we don't need to go down the tree
- If not, maybe we already found that state in another depth. Might be worth saving its children in the other cache, in case a future iteration finds this state again

(*) Caveat: we can't store score per state, because it depends on depth. So we store score per pair (state, depth).